### PR TITLE
update runelite sh script to pass cli args to client

### DIFF
--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -6,7 +6,7 @@
     "command": "runelite",
     "separate-locales": false,
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk11" 
+        "org.freedesktop.Sdk.Extension.openjdk11"
     ],
     "finish-args": [
         "--share=ipc",
@@ -64,7 +64,7 @@
                     "dest-filename": "runelite",
                     "commands": [
                         "for file in $XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-*; do ln -sf $file $XDG_RUNTIME_DIR/$(basename $file); done",
-                        "exec $JAVA_HOME/bin/java -jar /app/share/RuneLite.jar"
+                        "exec $JAVA_HOME/bin/java -jar /app/share/RuneLite.jar \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
This change allows arguments to be passed directly to the RuneLite client. This allows for the RuneLite flatpak to be used for multiple profiles, for example, as outlined here: https://github.com/runelite/runelite/wiki/General-Features#playing-with-multiple-accounts

Before this change, if you try to run the following, it defaults to `settings.properties`, which is not the expected behavior:

```bash
flatpak run --command=bash --devel net.runelite.RuneLite/x86_64/stable

# once inside the flatpak container, rune the following:
runelite --clientargs="--config=/home/me/.runelite/settings-2.properties"
```

```bash
# or from the host, you can run this:
flatpak run net.runelite.RuneLite/x86_64/stable --clientargs="--config=settings-2.properties"
```

So, to fix this, the `/app/bin/runelite` shell script simply needs to be updated to include the bash command args that were passed into the script,  via `$@`.

My IDE also cleaned up a loose whitespace character.

Signed-off-by: charles-m-knox <code@charlesmknox.com>

