### PR TITLE
Fix Discord integration

### DIFF
--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -17,7 +17,7 @@
         "--env=JAVA_HOME=/app/jre",
         "--talk-name=org.freedesktop.Notifications",
         "--filesystem=xdg-run/app/com.discordapp.Discord:create",
-        "--filesystem=~/.runelite:create",
+        "--persist=.runelite",
         "--persist=jagexcache"
     ],
     "modules": [
@@ -63,7 +63,7 @@
                     "type": "script",
                     "dest-filename": "runelite",
                     "commands": [
-                        "for file in $XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-*; do ln -sf $file $XDG_RUNTIME_DIR/$(basename $file); done",
+                        "ln -sf $XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0 $XDG_RUNTIME_DIR/discord-ipc-0",
                         "exec $JAVA_HOME/bin/java -jar /app/share/RuneLite.jar \"$@\""
                     ]
                 },


### PR DESCRIPTION
On my system at least (so presumably on all systems), the star does not get expended so the file is never really linked.
AFAIK discord won't create multiple `discord-ipc-` files as long as there aren't multiple discord session running at the same time.
If that is a problem, things can get revisited in the future.