### PR TITLE
update runtime to 21.08

### DIFF
--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -1,12 +1,12 @@
 {
     "id": "net.runelite.RuneLite",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "runelite",
     "separate-locales": false,
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk11"
+        "org.freedesktop.Sdk.Extension.openjdk"
     ],
     "finish-args": [
         "--share=ipc",
@@ -25,7 +25,7 @@
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk11/install.sh"
+                "/usr/lib/sdk/openjdk/install.sh"
             ]
         },
         {


### PR DESCRIPTION
Also uses the latest OpenJDK version (17 at the time of writing, instead of 11)

Fixes #19

As I said in the issue above, can't update to 22.08 yet because the OpenJDK package hasn't been updated in almost a year — which is a shame because a new JDK version would fix #16 as well