### PR TITLE
Update runtime to 21.08 and launcher to 2.5.0

### DIFF
--- a/net.runelite.RuneLite.appdata.xml
+++ b/net.runelite.RuneLite.appdata.xml
@@ -21,7 +21,7 @@
     </screenshots>
 
     <releases>
-        <release version="2.4.0" date="2022-02-21"></release>
+        <release version="2.5.0" date="2022-09-11"></release>
     </releases>
     <update_contact>rushsteve1_at_rushsteve1.us</update_contact>
 

--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -1,7 +1,7 @@
 {
     "id": "net.runelite.RuneLite",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "runelite",
     "separate-locales": false,

--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -69,8 +69,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/runelite/launcher/releases/download/2.4.0/RuneLite.jar",
-                    "sha256": "0371df868e2d803aa84a170cb685d9db04bd9a1bda80110f0f12ad0570328348"
+                    "url": "https://github.com/runelite/launcher/releases/download/2.5.0/RuneLite.jar",
+                    "sha256": "8383932134644c81ae41d4363052ce779fd5acce36455daf7477e57d72f9be81"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Supersedes both #17 and #20.

Regarding the OpenJDK update concerns, this one keeps it to 11. I don't think 22.08 has the extension for 11.