### PR TITLE
Update freedesktop to 22.08

### DIFF
--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.gnome.org/GNOME/libnotify/-/archive/0.7.9/libnotify-0.7.9.tar.gz",
-                    "sha256": "9bd4f5fa911d27567e7cc2d2d09d69356c16703c4e8d22c0b49a5c45651f3af0"
+                    "url": "https://gitlab.gnome.org/GNOME/libnotify/-/archive/0.8.1/libnotify-0.8.1.tar.gz",
+                    "sha256": "7c0b252edecbf08db50d775f9e720ecc03c742fb97c25f3966a8b7a4bedf8133"
                 }
             ],
             "cleanup": [

--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -1,7 +1,7 @@
 {
     "id": "net.runelite.RuneLite",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "runelite",
     "separate-locales": false,


### PR DESCRIPTION
OpenJDK 11 is now shipped in a [Freedesktop SDK extension](
https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11/tree/branch/22.08)!

I also updated libnotify to 0.8.1.
