### PR TITLE
Use persistent .runelite directory inside sandbox

### DIFF
--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -17,8 +17,7 @@
         "--env=JAVA_HOME=/app/jre",
         "--talk-name=org.freedesktop.Notifications",
         "--filesystem=xdg-run/app/com.discordapp.Discord:create",
-        "--filesystem=~/.runelite:create",
-        "--persist=jagexcache"
+        "--persist=.runelite"
     ],
     "modules": [
         {


### PR DESCRIPTION
instead of creating the directory in user's home.

Cherry picked from #14.