### PR TITLE
Fix screenshot links

### DIFF
--- a/net.runelite.RuneLite.appdata.xml
+++ b/net.runelite.RuneLite.appdata.xml
@@ -15,9 +15,9 @@
 
     <screenshots>
         <screenshot type="default">https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/screenshot.png</screenshot>
-        <screenshot>https://runelite.net/img/carousel/1.png</screenshot>
-        <screenshot>https://runelite.net/img/carousel/2.png</screenshot>
-        <screenshot>https://runelite.net/img/carousel/3.png</screenshot>
+        <screenshot>https://runelite.net/img/carousel/1.webp</screenshot>
+        <screenshot>https://runelite.net/img/carousel/2.webp</screenshot>
+        <screenshot>https://runelite.net/img/carousel/3.webp</screenshot>
     </screenshots>
 
     <releases>


### PR DESCRIPTION
These images were changed from PNG files to WEBP files in a recent runelite.net update for general site optimizations. [1]

[1]: https://github.com/runelite/runelite.net/commit/0f8a5e656a254a6dd9e3bcb9486959209e227ba8