### PR TITLE
update Runelite to 2.7.1

### DIFF
--- a/net.runelite.RuneLite.appdata.xml
+++ b/net.runelite.RuneLite.appdata.xml
@@ -21,7 +21,7 @@
     </screenshots>
 
     <releases>
-        <release version="2.6.10" date="2023-11-19"></release>
+        <release version="2.7.1" date="2024-03-17"></release>
     </releases>
     <update_contact>adam_at_runelite.net</update_contact>
 

--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -68,8 +68,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/runelite/launcher/releases/download/2.6.10/RuneLite.jar",
-                    "sha256": "b73561c714ad58984669f0b909731d4cc4c6bacdbf07d227006243d1b566138b"
+                    "url": "https://github.com/runelite/launcher/releases/download/2.7.1/RuneLite.jar",
+                    "sha256": "47a721fee0ff6d7b229af875d4ad29c0cb0f4459afcf7669d2a8aabf3ede1ebb"
                 },
                 {
                     "type": "file",

--- a/net.runelite.RuneLite.json
+++ b/net.runelite.RuneLite.json
@@ -55,7 +55,7 @@
                 "install -D RuneLite.jar /app/share/RuneLite.jar",
                 "install -Dm644 net.runelite.RuneLite.png /app/share/icons/hicolor/128x128/apps/net.runelite.RuneLite.png",
                 "install -Dm644 net.runelite.RuneLite.desktop /app/share/applications/net.runelite.RuneLite.desktop",
-                "install -Dm644 net.runelite.RuneLite.appdata.xml /app/share/appdata/net.runelite.RuneLite.appdata.xml"
+                "install -Dm644 net.runelite.RuneLite.metainfo.xml /app/share/metainfo/net.runelite.RuneLite.metainfo.xml"
             ],
             "sources": [
                 {
@@ -81,7 +81,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "net.runelite.RuneLite.appdata.xml"
+                    "path": "net.runelite.RuneLite.metainfo.xml"
                 }
             ]
         }

--- a/net.runelite.RuneLite.metainfo.xml
+++ b/net.runelite.RuneLite.metainfo.xml
@@ -1,23 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2019 Steven vanZyl -->
 <component type="desktop">
-    <id>net.runelite.RuneLite.desktop</id>
+    <id>net.runelite.RuneLite</id>
     <name>RuneLite</name>
-    <developer_name>RuneLite</developer_name>
+    <developer id="net.runelite">
+        <name>RuneLite</name>
+    </developer>
     <summary>RuneLite OSRS Client</summary>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>BSD-2-Clause</project_license>
     <url type="homepage">https://runelite.net</url>
+    <launchable type="desktop-id">net.runelite.RuneLite.desktop</launchable>
 
     <description>
         <p>RuneLite is a free, open-source and super fast client for Old School RuneScape.</p>
     </description>
 
     <screenshots>
-        <screenshot type="default">https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/screenshot.png</screenshot>
-        <screenshot>https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/1.png</screenshot>
-        <screenshot>https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/2.png</screenshot>
-        <screenshot>https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/3.png</screenshot>
+        <screenshot type="default">
+            <image>https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/screenshot.png</image>
+            <caption>Login screen</caption>
+        </screenshot>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/1.png</image>
+            <caption>Gameplay example of a player in the Chambers of Xeric raid</caption>
+        </screenshot>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/2.png</image>
+            <caption>Gameplay example of a player fighting with a lesser demon</caption>
+        </screenshot>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/flathub/net.runelite.RuneLite/master/3.png</image>
+            <caption>Gameplay example looking over Mount Karuulm in Zeah</caption>
+        </screenshot>
     </screenshots>
 
     <releases>


### PR DESCRIPTION
I tried to log in this morning and got a notification that RuneLite was out of date. While investigating, I noticed that the Flathub hasn't had a new release in a while